### PR TITLE
Add sgamepad_is_connected

### DIFF
--- a/sokol_gamepad.h
+++ b/sokol_gamepad.h
@@ -367,7 +367,8 @@ _SOKOL_PRIVATE void _sgamepad_record_state() {
 
     ++target_index;
     for ( ; target_index < SGAMEPAD_MAX_SUPPORTED_GAMEPADS; ++target_index) {
-        target_index->connected = false;
+        sgamepad_gamepad_state* target = _sgamepad.gamepad_states + target_index;
+        target->connected = false;
     }
 }
 


### PR DESCRIPTION
- adds a return value to sgamepad_get_gamepad_state to indicate whether the read values come from a connected joystick. (If return == index, success)
- adds a connected field to sgamepad_gamepad_state
- adds bool sgamepad_is_connected(unsigned int index)
- uses float_min and float_max instead of fmin fmax to solve MSVC issues that cause upcasting to double
- eliminates __cplusplus check on ARC features to enable use from with with ObjC++ in addition to ObjC
- logic not tested on Android because I'm not set up for Android development